### PR TITLE
using uv to simplify and speedup the CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,15 +21,15 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: astral-sh/setup-uv@v7
         with:
-          python-version: "3.9"
+          activate-environment: true
 
       # We still need to install pywin32 because
       # AutoDuck/py2d.py currently relies on runtime imports for introspection
       # Downloading latest release is faster than re-building
       - name: Install latest release
-        run: pip install --user --upgrade pywin32
+        run: uv pip install --upgrade pywin32
 
       - name: Generate PyWin32.chm help file
         run: python AutoDuck/make.py

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,8 +38,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.architecture }}
-          cache: pip
-          cache-dependency-path: .github/workflows/main.yml
           check-latest: true
           allow-prereleases: true
 
@@ -102,23 +100,16 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python-version }}
-          architecture: x64
-          cache: pip
-          cache-dependency-path: .github/workflows/main.yml
-          check-latest: true
-          allow-prereleases: true
-
-      - name: Install build module
-        run: pip install --upgrade build
+          activate-environment: true
 
       - name: Obtain ARM64 library files
         run: python .github\workflows\download-arm64-libs.py .\arm64libs
 
       - name: Build wheels
-        run: python -m build --wheel --config-setting=--build-option=build_ext --config-setting=--build-option=-L.\arm64libs --config-setting=--build-option=--plat-name=win-arm64 --config-setting=--build-option=build --config-setting=--build-option=--plat-name=win-arm64 --config-setting=--build-option=bdist_wheel --config-setting=--build-option=--plat-name=win-arm64
+        run: uv build --wheel --config-setting=--build-option=build_ext --config-setting=--build-option=-L.\arm64libs --config-setting=--build-option=--plat-name=win-arm64 --config-setting=--build-option=build --config-setting=--build-option=--plat-name=win-arm64 --config-setting=--build-option=bdist_wheel --config-setting=--build-option=--plat-name=win-arm64
 
       - uses: actions/upload-artifact@v4
         with:
@@ -146,15 +137,16 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v6
+      - uses: astral-sh/setup-uv@v7
         with:
           # This job only needs to target the oldest supported version
           python-version: "3.8"
-          cache: pip
-          cache-dependency-path: .github/workflows/main.yml
-      - run: pip install clang-format==18.1.* pycln
+          activate-environment: true
+      - run: uv pip install clang-format==18.1.* pycln
+
       # !cancelled(): Show issues even if the previous steps failed. But still fail the job
       - run: pycln . --config=pycln.toml --check
+
       - name: Run Ruff linter
         uses: astral-sh/ruff-action@v3
         with:
@@ -163,6 +155,7 @@ jobs:
       - name: Run Ruff formatter
         run: ruff format --check
         if: ${{ !cancelled() }}
+
       # Too many files to fit in a single command, also exclude vendored Scintilla and MAPIStubLibrary
       - run: |
           clang-format --Werror --dry-run $(git ls-files '*.cpp' ':!:com/win32comext/mapi/src/MAPIStubLibrary/')
@@ -182,14 +175,11 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v6
+      - uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python-version }}
-          cache: pip
-          cache-dependency-path: .github/workflows/main.yml
-          check-latest: true
-          allow-prereleases: true
-      - run: pip install types-setuptools PyOpenGL mypy==1.16.*
+          activate-environment: true
+      - run: uv pip install types-setuptools PyOpenGL mypy==1.16.*
 
       - run: mypy . --python-version=${{ matrix.python-version }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,8 @@ ENV/
 env.bak/
 venv.bak/
 .vagrant/
+# Not currently using a lock file
+uv.lock
 
 # other IDEs, MacOS, etc
 .idea/

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -7,6 +7,7 @@
   // Exclude from scanning when running pyright
   "exclude": [
     ".git/", // Avoids scanning git branch names ending in ".py"
+    ".venv",
     "build/",
     // Vendored
     "Pythonwin/Scintilla/",


### PR DESCRIPTION
(draft PR description to copy over when opening real PR)

uv is a fast and modern replacement for `setup-python`, `pip`, `build`, `venv`, `twine`\*

In the times below, I omitted the slowest and fastest times in a job matrix as outliers. The exact time save is hard to say, but the trend is clear:
- The CI step of installing Python (all jobs except native builds) goes from (sometimes\*\*) 50-60s down to 6-14.
- The CI step of installing `build` for cross-compilations goes from 3-14s down to 0 (no need to install extra dep)
- The CI step of installing checkers dependencies from ~9s down to ~2s
- The CI step of installing type-checkers dependencies  from 37-44s down to ~3s

\* Whilst `uv publish` *can* be used to replace twine for publishing, there are no changes needed to your current workflow and you can keep using twine as you were.
\*\* Most of the time, the  `actions/setup-python` step takes 6-18s, which would be equivalent, but it also sometimes randomly take around a minute for unknown reasons.