### PR TITLE
Migrate deprecated `Py_SetProgramName` & `PySys_SetArgv` w/ additional Exception handling

### DIFF
--- a/com/win32com/src/dllmain.cpp
+++ b/com/win32com/src/dllmain.cpp
@@ -270,7 +270,22 @@ HRESULT DoRegisterUnregister(LPCSTR fileName, int argc, char **argv)
     PyCom_DLLAddRef();
     {  // A scope for _celp
         CEnterLeavePython _celp;
-        PySys_SetArgv(argc, __wargv);
+        PyObject *sysArgv = PyList_New(argc);
+        if (sysArgv) {
+            for (int i = 0; i < argc; i++) {
+                PyObject *item = PyUnicode_FromWideChar(__wargv[i], -1);
+                if (!item) {
+                    Py_DECREF(sysArgv);
+                    sysArgv = NULL;
+                    break;
+                }
+                PyList_SET_ITEM(sysArgv, i, item);
+            }
+            if (sysArgv) {
+                PySys_SetObject("argv", sysArgv);
+                Py_DECREF(sysArgv);
+            }
+        }
 
         if (PyRun_SimpleFile(fp, (char *)fileName) != 0) {
             // Convert the Python error to a HRESULT.

--- a/pythonwin/start_pythonwin.pyw
+++ b/pythonwin/start_pythonwin.pyw
@@ -7,7 +7,8 @@ import pywin.framework.intpyapp  # noqa: F401 # InteractivePythonApp()
 import win32ui
 
 # Pretend this script doesn't exist, or pythonwin tries to edit it
-sys.argv[:] = sys.argv[1:] or [""]  # like PySys_SetArgv(Ex)
+# like setting PyConfig.argv: drop script name, default to [""]
+sys.argv[:] = sys.argv[1:] or [""]
 if sys.path[0] not in ("", ".", os.getcwd()):
     sys.path.insert(0, os.getcwd())
 # And bootstrap the app.

--- a/pythonwin/win32uimodule.cpp
+++ b/pythonwin/win32uimodule.cpp
@@ -2564,7 +2564,22 @@ extern "C" PYW_EXPORT BOOL Win32uiApplicationInit(Win32uiHostGlue *pGlue, const 
         int myargc;
         LPWSTR *myargv = CommandLineToArgvW(GetCommandLineW(), &myargc);
         if (myargv) {
-            PySys_SetArgv(myargc - 1, myargv + 1);
+            PyObject *sysArgv = PyList_New(myargc - 1);
+            if (sysArgv) {
+                for (int i = 0; i < myargc - 1; i++) {
+                    PyObject *item = PyUnicode_FromWideChar(myargv[i + 1], -1);
+                    if (!item) {
+                        Py_DECREF(sysArgv);
+                        sysArgv = NULL;
+                        break;
+                    }
+                    PyList_SET_ITEM(sysArgv, i, item);
+                }
+                if (sysArgv) {
+                    PySys_SetObject("argv", sysArgv);
+                    Py_DECREF(sysArgv);
+                }
+            }
             LocalFree(myargv);
         }
     }

--- a/win32/src/PythonService.cpp
+++ b/win32/src/PythonService.cpp
@@ -563,23 +563,38 @@ static void PyService_InitPython()
     // knows how to get the .EXE name when it needs.
     int pyargc;
     WCHAR **pyargv = CommandLineToArgvW(GetCommandLineW(), &pyargc);
-    if (pyargv)
-        Py_SetProgramName(pyargv[0]);
+
+    PyConfig config;
+    PyConfig_InitPythonConfig(&config);
+    PyStatus status;
+    if (pyargv) {
+        status = PyConfig_SetString(&config, &config.program_name, pyargv[0]);
+        if (PyStatus_Exception(status)) {
+            PyConfig_Clear(&config);
+            Py_ExitStatusException(status);
+        }
+        // Notes about argv: When debugging a service, the argv is currently
+        // the *full* args, including the "-debug servicename" args.  This
+        // isn't ideal, but has been this way for a few builds, and a good
+        // fix isn't clear - should 'servicename' be presented in argv, even
+        // though it never is when running as a real service?
+        status = PyConfig_SetArgv(&config, pyargc, pyargv);
+        if (PyStatus_Exception(status)) {
+            PyConfig_Clear(&config);
+            Py_ExitStatusException(status);
+        }
+    }
 
 #ifdef BUILD_FREEZE
     PyInitFrozenExtensions();
 #endif
-    Py_Initialize();
+    status = Py_InitializeFromConfig(&config);
+    PyConfig_Clear(&config);
+    if (PyStatus_Exception(status))
+        Py_ExitStatusException(status);
 #ifdef BUILD_FREEZE
     PyWinFreeze_ExeInit();
 #endif
-    // Notes about argv: When debugging a service, the argv is currently
-    // the *full* args, including the "-debug servicename" args.  This
-    // isn't ideal, but has been this way for a few builds, and a good
-    // fix isn't clear - should 'servicename' be presented in argv, even
-    // though it never is when running as a real service?
-    if (pyargv)
-        PySys_SetArgv(pyargc, pyargv);
     PyInit_servicemanager();
     LocalFree(pyargv);
 }
@@ -1398,11 +1413,22 @@ int _tmain(int argc, TCHAR **argv)
     FARPROC proc;
     int dummy;
     wchar_t **program = CommandLineToArgvW(GetCommandLineW(), &dummy);
+
+    PyConfig config;
+    PyConfig_InitPythonConfig(&config);
+    PyStatus status;
     if (program != NULL) {
-        Py_SetProgramName(program[0]);
-        // do not free `program` since Py_SetProgramName does not copy it.
+        status = PyConfig_SetString(&config, &config.program_name, program[0]);
+        LocalFree(program);
+        if (PyStatus_Exception(status)) {
+            PyConfig_Clear(&config);
+            Py_ExitStatusException(status);
+        }
     }
-    Py_Initialize();
+    status = Py_InitializeFromConfig(&config);
+    PyConfig_Clear(&config);
+    if (PyStatus_Exception(status))
+        Py_ExitStatusException(status);
     module = PyImport_ImportModule("servicemanager");
     if (!module)
         goto failed;


### PR DESCRIPTION
Works towards:
- https://github.com/mhammond/pywin32/issues/2588
- https://github.com/mhammond/pywin32/issues/1289

Disclaimer: Untested and helped by coding agent